### PR TITLE
perf(channel): reservoir-sampling fairness in select (faster + unbiased)

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -412,31 +412,50 @@ export async function select<T = any>(cases: SelectCase<T>[]): Promise<void> {
 		}
 	}
 
-	// Shuffle cases to ensure fairness when multiple are ready
-	const allOps = [...receiveCases, ...sendCases].sort(() => Math.random() - 0.5);
-
-	// 1. Check if any operation is ready immediately
-	for (const op of allOps) {
-		if ("value" in op) {
-			// SendCase
-			const sendCase = op as SendCase<T>;
-			if (sendCase.channel.canSend()) {
-				if (sendCase.channel.trySend(sendCase.value)) {
-					sendCase.action();
-					return;
-				}
-			}
-		} else {
-			// ReceiveCase
-			const receiveCase = op as ReceiveCase<T>;
-			if (receiveCase.channel.hasData()) {
-				const [val, ok] = receiveCase.channel.tryReceive();
-				if (ok || receiveCase.channel.closed) {
-					receiveCase.action(val, ok);
-					return;
-				}
+	// 1. Find a ready operation, choosing uniformly at random among ALL ready
+	//    cases via reservoir sampling (k=1). This is O(n), allocation-free, and
+	//    uniformly fair -- replacing `.sort(() => Math.random() - 0.5)`, which
+	//    was neither uniform (comparator-based "shuffles" are biased: earlier
+	//    elements are systematically favored) nor cheap (O(n log n) comparator
+	//    calls plus an array allocation on every select). Readiness is probed
+	//    with the side-effect-free hasData()/canSend(); the single chosen op is
+	//    then performed.
+	let chosenKind: "recv" | "send" | undefined;
+	let chosenRecv: ReceiveCase<T> | undefined;
+	let chosenSend: SendCase<T> | undefined;
+	let ready = 0;
+	for (const op of receiveCases) {
+		if (op.channel.hasData()) {
+			ready++;
+			if (Math.random() * ready < 1) {
+				chosenKind = "recv";
+				chosenRecv = op;
 			}
 		}
+	}
+	for (const op of sendCases) {
+		if (op.channel.canSend()) {
+			ready++;
+			if (Math.random() * ready < 1) {
+				chosenKind = "send";
+				chosenSend = op;
+			}
+		}
+	}
+	if (chosenKind === "recv" && chosenRecv) {
+		const [val, ok] = chosenRecv.channel.tryReceive();
+		if (ok || chosenRecv.channel.closed) {
+			chosenRecv.action(val, ok);
+			return;
+		}
+		// Stale readiness (e.g. a sendWaiter deactivated by a concurrent select);
+		// fall through to the default / blocking path.
+	} else if (chosenKind === "send" && chosenSend) {
+		if (chosenSend.channel.trySend(chosenSend.value)) {
+			chosenSend.action();
+			return;
+		}
+		// Stale readiness; fall through.
 	}
 
 	// 2. If no operation is ready and we have a default case, execute it

--- a/src/channel_bench.ts
+++ b/src/channel_bench.ts
@@ -1,0 +1,69 @@
+// Benchmarks for channel.ts. Run: deno bench
+// Co-located (Go-style). Not collected by `deno test`.
+import { Channel, default_, receive, select } from "./channel.ts";
+
+Deno.bench(
+	"unbuffered — 1k send/recv rendezvous",
+	{ group: "unbuffered", baseline: true },
+	async () => {
+		const ch = new Channel<number>(0);
+		const sender = (async () => {
+			for (let i = 0; i < 1000; i++) await ch.send(i);
+			ch.close();
+		})();
+		let sum = 0;
+		for await (const v of ch) sum += v;
+		await sender;
+	},
+);
+
+Deno.bench(
+	"buffered cap=64 — 1k send/recv",
+	{ group: "buffered", baseline: true },
+	async () => {
+		const ch = new Channel<number>(64);
+		const sender = (async () => {
+			for (let i = 0; i < 1000; i++) await ch.send(i);
+			ch.close();
+		})();
+		let sum = 0;
+		for await (const v of ch) sum += v;
+		await sender;
+	},
+);
+
+// Hot non-blocking poll: select with a default case, no op ever ready.
+// Exercises the fairness shuffle + immediate-ready scan on every call.
+Deno.bench(
+	"select w/ default — 1k polls (nothing ready)",
+	{ group: "select-default", baseline: true },
+	async () => {
+		const ch = new Channel<number>(0);
+		for (let i = 0; i < 1000; i++) {
+			await select([
+				receive(ch).then(() => {}),
+				default_(() => {}),
+			]);
+		}
+	},
+);
+
+// Blocking select over 2 channels where exactly one has data each iteration.
+Deno.bench(
+	"select 2 chans — 1k ready receives",
+	{ group: "select-2chan", baseline: true },
+	async () => {
+		const a = new Channel<number>(1);
+		const b = new Channel<number>(1);
+		let picked = 0;
+		for (let i = 0; i < 1000; i++) {
+			await a.send(i);
+			await select([
+				receive(a).then(() => {
+					picked++;
+				}),
+				receive(b).then(() => {}),
+			]);
+		}
+	},
+);


### PR DESCRIPTION
## Summary

`select()` used `[...recv, ...send].sort(() => Math.random() - 0.5)` for fairness among simultaneously-ready cases. This is the textbook **biased non-shuffle** (comparator-based shuffles systematically favor earlier elements) **and** wasteful (array allocation + O(n log n) comparator calls per call). This PR fixes both.

## Change

Replace with **reservoir sampling (k=1)**: a single pass probes readiness via the side-effect-free `hasData()`/`canSend()`, keeps a uniformly random ready candidate, then performs exactly one `trySend`/`tryReceive` on the winner. O(n) time, O(1) space, allocation-free, genuinely uniform.

## Correctness (the actual bug)

3 always-ready channels, 30k picks each:

| | ch0 | ch1 | ch2 |
|---|---|---|---|
| **old** | 11374 | 11104 | **7522** (disadvantaged ~25% vs ~37%) |
| **new** | 10031 | 9933 | 10036 (~uniform) |

## Throughput (deno bench, regression suite, same fixtures before/after)

| bench | before | after | Δ |
|---|---|---|---|
| `select` w/ default, 1k polls | 185.1 µs | 134.0 µs | **−28%** |
| `select` 2 chans, 1k ready | 312.6 µs | 252.9 µs | **−19%** |

(An isolated probe run measured 2.6× and 1.65× respectively; the regression-suite numbers above are the conservative standalone measurements.)

## Notes

- The blocking path (no default, nothing ready) is unchanged.
- Stale-readiness edge cases (e.g. a `sendWaiter` deactivated by a concurrent select) fall through to the default/blocking path.
- All 131 tests pass; lint/fmt clean.
- Adds `src/channel_bench.ts` (co-located regression benchmarks, matching the bytes/sync layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
