### PR TITLE
chore: release 0.10.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
   "name": "@okdaichi/golikejs",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "exports": {
     ".": "./src/mod.ts",
     "./sync": "./src/sync/mod.ts",


### PR DESCRIPTION
## Version bump: 0.9.0 → 0.10.0

Bundles the two merged performance PRs:

- **#17** `perf(bytes)`: first-byte scan in `index`/`lastIndex` (−60–70%, cascades to `contains`/`count`/`cut`/`split`), zero-copy ASCII fast path in `fields` (−90%), 4-byte chunked `equal` (−48%).
- **#18** `perf(channel)`: reservoir-sampling fairness in `select` — faster (−19–28%) **and** fixes a biased-shuffle correctness bug.

### Why minor (not patch)

- `fields` now returns **aliased subslices** for ASCII input — matches its documented *"subslices of s"* contract and Go's `bytes.Fields`, but is a behavioral change for any caller that mutated a field expecting independence.
- `select`'s fairness distribution changed (biased → uniform).

### Verification

- `deno publish --dry-run` passes (all modules check, no slow types in the public API).
- All 131 tests pass; lint/fmt clean (on the bundled PRs).

### Publish

The actual JSR publish (`deno publish`) is a separate manual step run by the maintainer — there's no publish workflow and it needs owner credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
