### PR TITLE
chore(ci): require-changelog gate + tag-driven JSR release automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep GitHub Actions versions current (checkout, setup-deno, etc.)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ How was this tested?
 
 ## Checklist
 
-- [ ] Comments added for complex logic
-- [ ] Documentation updated if needed
+- [ ] **CHANGELOG.md updated** (or `no-changelog` label applied)
 - [ ] Tests added/updated
+- [ ] Documentation updated if needed
+- [ ] Comments added for complex logic

--- a/.github/scripts/extract_changelog.ts
+++ b/.github/scripts/extract_changelog.ts
@@ -1,0 +1,18 @@
+// Extracts the changelog body for a given version from CHANGELOG.md.
+//
+// Usage: deno run -A .github/scripts/extract_changelog.ts <version>
+// Prints the section text: everything after the `## [<version>] ...` heading up
+// to (but not including) the next `## [` heading. Prints nothing (exit 0) if
+// the section is absent.
+const version = Deno.args[0];
+if (!version) {
+	console.error("usage: extract_changelog.ts <version>");
+	Deno.exit(2);
+}
+const md = await Deno.readTextFile("CHANGELOG.md");
+const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const re = new RegExp(
+	`##\\s*\\[${escaped}\\][^\\n]*\\n([\\s\\S]*?)(?=\\n##\\s*\\[|$)`,
+);
+const m = md.match(re);
+console.log((m?.[1] ?? "").trim());

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+# Tag-driven release for the JSR package @okdaichi/golikejs.
+# Push a tag matching `v<deno.json version>` (e.g. v0.10.0) to publish to JSR
+# and create a GitHub Release.
+#
+# Prerequisite: add a `JSR_TOKEN` secret (create one at https://jsr.io).
+# Alternative (no secret): JSR "Publish from GitHub Actions" via OIDC — grant
+# `id-token: write` (already set below) and enable the pipeline on your jsr.io
+# scope, then drop `--token ${{ secrets.JSR_TOKEN }}`.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # create GitHub Release
+  id-token: write # JSR OIDC publish (if used instead of JSR_TOKEN)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Publish to JSR & create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Verify tag matches deno.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}" # strip leading "v"
+          VERSION=$(deno eval 'console.log(JSON.parse(Deno.readTextFileSync("deno.json")).version)')
+          echo "Tag: $TAG | deno.json: $VERSION"
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::git tag '$TAG' does not match deno.json version '$VERSION'"
+            exit 1
+          fi
+
+      - name: Sanity checks (fmt, lint, type-check, tests)
+        run: |
+          deno fmt --check
+          deno lint
+          deno check src/**/*.ts
+          deno test
+
+      - name: Publish to JSR
+        run: deno publish --token ${{ secrets.JSR_TOKEN }}
+
+      - name: Extract changelog section for this version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          deno run -A .github/scripts/extract_changelog.ts "$VERSION" > release_notes.md
+          {
+            echo "## ${GITHUB_REF_NAME}"
+            echo ""
+            cat release_notes.md
+          } > release_body.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release_body.md
+          generate_release_notes: true
+          fail_on_unmatched_files: false

--- a/.github/workflows/require-changelog.yml
+++ b/.github/workflows/require-changelog.yml
@@ -1,0 +1,67 @@
+name: "Require CHANGELOG Update"
+
+# Adapted from the qumo project. Enforces that PRs carrying non-trivial changes
+# also add an entry to CHANGELOG.md. Escape hatches: the `no-changelog` label,
+# and bot authors (dependabot, etc.).
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-changelog:
+    # Skip for bots
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Short-circuit on no-changelog label
+        id: check_label
+        if: contains(github.event.pull_request.labels.*.name, 'no-changelog')
+        run: echo "no-changelog label present — skipping CHANGELOG check."
+
+      - name: Checkout PR branch
+        if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for non-trivial changes
+        id: changed_files
+        if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
+        run: |
+          # Native git diff (not tj-actions/changed-files, CVE-2025-30066).
+          # any_changed is true if any changed file is NOT in the ignore set
+          # (.github/**, docs/**, *_test.ts, *_bench.ts, *.md) — i.e. a change
+          # that warrants a CHANGELOG entry.
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | grep -vE '^(\.github|docs)/|_test\.ts$|_bench\.ts$|\.md$' | grep -q .; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify CHANGELOG.md content modification
+        if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog') && steps.changed_files.outputs.any_changed == 'true'"
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -q '^CHANGELOG\.md$'; then
+            # Ensure there are actual additions, not just deletions/whitespace.
+            ADDITIONS=$(git diff "origin/${{ github.base_ref }}...HEAD" -- CHANGELOG.md | grep -cE '^\+[^+]') || true
+            if [ "$ADDITIONS" -gt 0 ]; then
+              echo "CHANGELOG.md has valid updates ($ADDITIONS lines added)."
+            else
+              echo "::error file=CHANGELOG.md,line=1::CHANGELOG.md was modified, but no new content was added. Please add an entry."
+              exit 1
+            fi
+          else
+            echo "::error file=CHANGELOG.md,line=1::Pull request must include a change to CHANGELOG.md (add a new entry, or apply the 'no-changelog' label if omitted intentionally)."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,40 @@ The format is based on "Keep a Changelog" and this project adheres to Semantic V
 
 ### Added
 
+- **CI/release automation**: Required-changelog workflow (enforces CHANGELOG.md updates on non-trivial PRs, with a `no-changelog` label escape hatch) and a tag-driven Release workflow (`deno publish` to JSR + GitHub Release on `v*` tags).
 - **`sync.Once`**: Added Go-style `Once` synchronization primitive to the sync package.
   - Ensures a function is executed exactly once, even under concurrent calls
   - Promise-based implementation optimized for JavaScript's event loop
   - Full type safety with generic return types
   - Handles errors while marking the operation as "done" (matching Go semantics)
   - Includes comprehensive test suite (9 test cases) covering concurrent execution, error handling, and type preservation
+
+## [0.10.0] - 2026-07-06
+
+### Changed
+
+- **`bytes.index` / `bytes.lastIndex`**: Replaced the O(n·m) nested-loop search with a first-byte scan via native `Uint8Array.indexOf`/`lastIndexOf` plus a short-circuit tail compare (the strategy production Go's `bytes.Index` uses). Throughput wins cascade to `contains`, `count`, `cut`, and `split`, all of which delegate to `index`.
+- **`bytes.fields`**: Added a zero-copy ASCII fast path — a single byte scan returning subslices of the input (matching the documented "subslices of s" contract and Go's `bytes.Fields`). Non-ASCII input falls back to the unchanged `/\s/`-based path. **Behavior note:** for ASCII input the returned subslices now alias `s`; callers needing independent memory should copy.
+- **`bytes.equal`**: Compare 4 bytes at a time via aligned `Uint32Array` views (~1.9× faster), falling back to a byte loop for unaligned subarrays.
+
+### Fixed
+
+- **`channel.select`**: Replaced the biased `.sort(() => Math.random() - 0.5)` fairness step with reservoir sampling (k=1), which is genuinely uniform, O(n), allocation-free, and faster. The previous shuffle systematically disadvantaged later cases.
+
+### Performance
+
+| Operation | Before | After | Δ |
+| --- | --- | --- | --- |
+| `index` (64 KiB, 8-byte needle) | 81.3 µs | 25.2 µs | −69% |
+| `contains` | 78.7 µs | 26.5 µs | −66% |
+| `count` | 77.9 µs | 26.5 µs | −66% |
+| `cut` | 79.8 µs | 25.6 µs | −68% |
+| `split` | 77.5 µs | 25.2 µs | −67% |
+| `lastIndex` | 66.5 µs | 27.3 µs | −59% |
+| `fields` (1.7 KiB ASCII) | 137.4 µs | 13.2 µs | −90% |
+| `equal` (1 KiB) | 372.4 ns | 192.2 ns | −48% |
+| `select` w/ default (1k polls) | 185.1 µs | 134.0 µs | −28% |
+| `select` 2 chans (1k ready) | 312.6 µs | 252.9 µs | −19% |
 
 ## [0.6.1] - 2025-12-09
 


### PR DESCRIPTION
## Description

Sets up the repo for maintained releases, inspired by the qumo project's layout. Adds a required-changelog gate and tag-driven JSR release automation.

## Changes

- **`.github/workflows/require-changelog.yml`** — enforces that PRs with non-trivial changes also add a `CHANGELOG.md` entry. Escape hatches: the `no-changelog` label and bot authors. Uses native `git diff` (not `tj-actions/changed-files` — CVE-2025-30066). Ignore set: `.github/`, `docs/`, `*_test.ts`, `*_bench.ts`, `*.md`.
- **`.github/workflows/release.yml`** — tag-driven. Pushing a `v*` tag: verifies it matches `deno.json` version → runs fmt/lint/check/test → `deno publish` to JSR → creates a GitHub Release with the matching CHANGELOG section. Supports `JSR_TOKEN` (default) or OIDC publish.
- **`.github/scripts/extract_changelog.ts`** — testable Deno helper to extract a version's changelog section (replaces a fragile shell-quoted `node -e` regex).
- **`.github/dependabot.yml`** — weekly `github-actions` updates.
- **PR template** — added a `CHANGELOG.md` checklist item.
- **`CHANGELOG.md`** — added `[0.10.0]` (perf work from #17/#18) and an `[Unreleased]` note for this setup.

## How releasing works after this merges

1. Maintainer adds a `JSR_TOKEN` secret (create at https://jsr.io), or enables JSR OIDC publish.
2. To release: `git tag v0.10.0 && git push --tags` → workflow publishes to JSR + creates the GitHub Release.

## Testing

- Both workflows validated as YAML (`@std/yaml` parse).
- `extract_changelog.ts` tested locally: pulls the correct `[0.10.0]` section; empty for a missing version.
- The version-match `deno eval` snippet returns `0.10.0`.
- This PR's files all fall in the changelog-ignore set, so the new gate won't block its own merge.

## Notes / prerequisites

- **Action required before first release:** add `JSR_TOKEN` secret (or configure JSR OIDC). Documented in `release.yml`.
- The CHANGELOG has a gap (0.7–0.9 were never recorded); I did **not** backfill those (no reliable record). Going forward the gate keeps it current.
- Did not touch the existing `ci.yml` / `runtime_test.yml`.

## Checklist

- [x] **CHANGELOG.md updated**
- [x] Tests added/updated (N/A — infra; helper script type-checked + manually tested)
- [x] Documentation updated if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
