### PR TITLE
chore(release): OIDC publish (no secret) + backfill CHANGELOG 0.7–0.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,9 @@ name: Release
 # Push a tag matching `v<deno.json version>` (e.g. v0.10.0) to publish to JSR
 # and create a GitHub Release.
 #
-# Prerequisite: add a `JSR_TOKEN` secret (create one at https://jsr.io).
-# Alternative (no secret): JSR "Publish from GitHub Actions" via OIDC — grant
-# `id-token: write` (already set below) and enable the pipeline on your jsr.io
-# scope, then drop `--token ${{ secrets.JSR_TOKEN }}`.
+# Publishing authenticates automatically via OIDC (no secret required): the
+# package is linked to this GitHub repo on jsr.io, and the `id-token: write`
+# permission below enables that. See https://jsr.io/docs/publishing#oidc .
 
 on:
   push:
@@ -16,7 +15,7 @@ on:
 
 permissions:
   contents: write # create GitHub Release
-  id-token: write # JSR OIDC publish (if used instead of JSR_TOKEN)
+  id-token: write # JSR OIDC publish
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -55,7 +54,7 @@ jobs:
           deno test
 
       - name: Publish to JSR
-        run: deno publish --token ${{ secrets.JSR_TOKEN }}
+        run: deno publish
 
       - name: Extract changelog section for this version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,6 @@ The format is based on "Keep a Changelog" and this project adheres to Semantic V
 ### Added
 
 - **CI/release automation**: Required-changelog workflow (enforces CHANGELOG.md updates on non-trivial PRs, with a `no-changelog` label escape hatch) and a tag-driven Release workflow (`deno publish` to JSR + GitHub Release on `v*` tags).
-- **`sync.Once`**: Added Go-style `Once` synchronization primitive to the sync package.
-  - Ensures a function is executed exactly once, even under concurrent calls
-  - Promise-based implementation optimized for JavaScript's event loop
-  - Full type safety with generic return types
-  - Handles errors while marking the operation as "done" (matching Go semantics)
-  - Includes comprehensive test suite (9 test cases) covering concurrent execution, error handling, and type preservation
 
 ## [0.10.0] - 2026-07-06
 
@@ -44,6 +38,38 @@ The format is based on "Keep a Changelog" and this project adheres to Semantic V
 | `equal` (1 KiB) | 372.4 ns | 192.2 ns | −48% |
 | `select` w/ default (1k polls) | 185.1 µs | 134.0 µs | −28% |
 | `select` 2 chans (1k ready) | 312.6 µs | 252.9 µs | −19% |
+
+## [0.9.0] - 2026-04-25
+
+### Notes
+
+- No user-facing changes since 0.8.0 (republish).
+
+## [0.8.0] - 2026-04-25
+
+### Added
+
+- **`channel`**: Major overhaul of the Channel primitive.
+  - Buffered and unbuffered channels.
+  - Async iterator support (`for await ... of`).
+  - Directional `SendChan` / `ReceiveChan` interfaces.
+  - `Channel.from(iterable)` static factory.
+  - Enhanced `select` handling multiple cases with a `default` case.
+  - Comprehensive test coverage for channel operations, async iteration, and select.
+
+### Changed
+
+- **`channel`**: `send` and `receive` accept an options object (e.g. `AbortSignal` and an internal `isActive` predicate) to support cancellation and `select` coordination.
+
+## [0.7.0] - 2025-12-24
+
+### Added
+
+- **`sync.Once`**: Go-style `Once` synchronization primitive — executes a function exactly once, even under concurrent calls. Promise-based, fully typed with generic return types, and treats a throwing function as "done" (matching Go semantics).
+
+### Changed
+
+- **Package name**: Package prefix changed from `@okudai/golikejs` to `@okdaichi/golikejs` to match the updated username. *(Also previously noted under 0.6.1.)*
 
 ## [0.6.1] - 2025-12-09
 


### PR DESCRIPTION
Two follow-ups to the release setup (#20):

## 1. OIDC publish — no secret needed

You pointed out JSR authenticates automatically via OIDC since the package is linked to this repo. Switched the publish step from `deno publish --token JSR_TOKEN` to plain `deno publish` (the `id-token: write` permission was already present). **No `JSR_TOKEN` secret is required.**

Kept **tag-driven** triggering (`on: push: tags: v*`) rather than JSR's example `push: branches: main`, because publish-on-main would fail with "version already exists" on every merge that doesn't bump the version (e.g. the setup PR). Tag-driven publishes only on deliberate releases.

## 2. CHANGELOG backfill 0.7–0.9

Reconstructed from git history (no behavioral changes):

- **[0.7.0]** (2025-12-24): `sync.Once` primitive; `@okudai` → `@okdaichi` rename.
- **[0.8.0]** (2026-04-25): Channel overhaul — buffered/unbuffered, async iterator, `SendChan`/`ReceiveChan`, `Channel.from`, multi-case `select` with `default`; `send`/`receive` options object (`AbortSignal` / `isActive`).
- **[0.9.0]** (2026-04-25): republish, no user-facing changes.
- Moved the misplaced `sync.Once` bullet out of `[Unreleased]` into `[0.7.0]` where it actually shipped.

## After this merges — release is one command (no secret needed now)

```bash
git tag v0.10.0
git push --tags
```

The Release workflow verifies the tag matches `deno.json`, runs checks, publishes to JSR via OIDC, and creates the GitHub Release with the `[0.10.0]` changelog section.

## Notes

- 0.9.0 and 0.8.0 share the same date — they were cut back-to-back on main; 0.9.0 had no feature commits.
- The package rename is documented under both 0.6.1 (existing) and 0.7.0 (where the code commit lands); noted explicitly to avoid confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
